### PR TITLE
#21 Make API endpoints root (remove /api prefix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Current branch: `feature/#5-setup-frontend` - setting up the Nuxt frontend.
 ### Environment Variables
 ```
 # Backend API configuration
-NUXT_PUBLIC_API_BASE_URL=http://localhost:8000/api
+NUXT_PUBLIC_API_BASE_URL=http://localhost:8000
 ```
 
 ### Common Development Commands
@@ -349,7 +349,7 @@ Feature tests inherit from `Tests\TestCase` which provides:
 Example feature test:
 ```php
 public function test_can_fetch_coins() {
-    $response = $this->get('/api/v1/coins');
+    $response = $this->get('/v1/coins');
     $response->assertStatus(200);
     $response->assertJsonStructure(['data' => ['*' => ['id', 'name', 'symbol']]]);
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Cryptobro is a monorepo cryptocurrency price tracking application with:
 
 4. **Open your browser:**
    - Frontend: http://localhost:3000
-   - Backend API: http://localhost:8000/api/v1/health
+   - Backend API: http://localhost:8000/v1/health
 
 ## Project Structure
 
@@ -146,10 +146,10 @@ npm run lint
 
 | Method | Endpoint               | Description                    |
 |--------|------------------------|--------------------------------|
-| GET    | `/api/v1/health`           | Health check                   |
-| GET    | `/api/v1/coins/markets`    | Top 10 cryptocurrencies        |
-| GET    | `/api/v1/coins/search?q=*` | Search cryptocurrencies        |
-| GET    | `/api/v1/coins/{symbol}`   | Get coin details by symbol     |
+| GET    | `/v1/health`           | Health check                   |
+| GET    | `/v1/coins/markets`    | Top 10 cryptocurrencies        |
+| GET    | `/v1/coins/search?q=*` | Search cryptocurrencies        |
+| GET    | `/v1/coins/{symbol}`   | Get coin details by symbol     |
 
 See [API Documentation](backend/API.md) for detailed endpoint specifications.
 

--- a/backend/API.md
+++ b/backend/API.md
@@ -1,7 +1,7 @@
 # Cryptobro API Documentation
 
 Version: 1.0
-Base URL: `http://localhost:8000/api/v1` (development)
+Base URL: `http://localhost:8000/v1` (development)
 
 ## Overview
 
@@ -39,7 +39,7 @@ All API responses follow a consistent structure:
 
 Check if the API is running and responsive.
 
-**Endpoint:** `GET /api/v1/health`
+**Endpoint:** `GET /v1/health`
 
 **Response:**
 ```json
@@ -58,7 +58,7 @@ Check if the API is running and responsive.
 
 Retrieve the top 10 cryptocurrencies by market capitalization.
 
-**Endpoint:** `GET /api/v1/coins/markets`
+**Endpoint:** `GET /v1/coins/markets`
 
 **Caching:** 60 seconds
 
@@ -106,7 +106,7 @@ Retrieve the top 10 cryptocurrencies by market capitalization.
 
 Search for cryptocurrencies by name or symbol.
 
-**Endpoint:** `GET /api/v1/coins/search`
+**Endpoint:** `GET /v1/coins/search`
 
 **Query Parameters:**
 | Parameter | Type   | Required | Description                          |
@@ -115,7 +115,7 @@ Search for cryptocurrencies by name or symbol.
 
 **Example Request:**
 ```
-GET /api/v1/coins/search?q=bitcoin
+GET /v1/coins/search?q=bitcoin
 ```
 
 **Caching:** 300 seconds (5 minutes)
@@ -168,7 +168,7 @@ GET /api/v1/coins/search?q=bitcoin
 
 Get detailed information for a specific cryptocurrency by its symbol.
 
-**Endpoint:** `GET /api/v1/coins/{symbol}`
+**Endpoint:** `GET /v1/coins/{symbol}`
 
 **Path Parameters:**
 | Parameter | Type   | Description                              |
@@ -177,7 +177,7 @@ Get detailed information for a specific cryptocurrency by its symbol.
 
 **Example Request:**
 ```
-GET /api/v1/coins/btc
+GET /v1/coins/btc
 ```
 
 **Caching:** 60 seconds per coin
@@ -293,36 +293,36 @@ No explicit rate limiting is currently enforced on the API endpoints.
 
 **Get top cryptocurrencies:**
 ```bash
-curl http://localhost:8000/api/v1/coins/markets
+curl http://localhost:8000/v1/coins/markets
 ```
 
 **Search for a cryptocurrency:**
 ```bash
-curl "http://localhost:8000/api/v1/coins/search?q=ethereum"
+curl "http://localhost:8000/v1/coins/search?q=ethereum"
 ```
 
 **Get Bitcoin details:**
 ```bash
-curl http://localhost:8000/api/v1/coins/btc
+curl http://localhost:8000/v1/coins/btc
 ```
 
 ### Using JavaScript (Fetch API)
 
 ```javascript
 // Get top cryptocurrencies
-fetch('http://localhost:8000/api/v1/coins/markets')
+fetch('http://localhost:8000/v1/coins/markets')
   .then(response => response.json())
   .then(data => console.log(data))
   .catch(error => console.error('Error:', error));
 
 // Search for cryptocurrencies
-fetch('http://localhost:8000/api/v1/coins/search?q=doge')
+fetch('http://localhost:8000/v1/coins/search?q=doge')
   .then(response => response.json())
   .then(data => console.log(data))
   .catch(error => console.error('Error:', error));
 
 // Get coin details
-fetch('http://localhost:8000/api/v1/coins/eth')
+fetch('http://localhost:8000/v1/coins/eth')
   .then(response => response.json())
   .then(data => console.log(data))
   .catch(error => console.error('Error:', error));

--- a/backend/app/Http/Middleware/SecurityHeaders.php
+++ b/backend/app/Http/Middleware/SecurityHeaders.php
@@ -30,7 +30,7 @@ class SecurityHeaders
         $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
 
         // Prevent caching of sensitive data
-        if ($request->is('api/*')) {
+        if ($request->is('v1/*')) {
             $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
             $response->headers->set('Pragma', 'no-cache');
         }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -8,6 +8,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',
+        apiPrefix: '', // Remove /api prefix - routes are now at root (e.g., /v1/coins/markets)
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*'],
+    'paths' => ['v1/*'],
 
     'allowed_methods' => ['GET', 'OPTIONS'],
 

--- a/backend/tests/Feature/CoinControllerTest.php
+++ b/backend/tests/Feature/CoinControllerTest.php
@@ -61,7 +61,7 @@ class CoinControllerTest extends TestCase
             }))
             ->willReturn($mockCoins);
 
-        $response = $this->get('/api/v1/coins/markets');
+        $response = $this->get('/v1/coins/markets');
 
         $response->assertStatus(200);
         $response->assertJson([
@@ -103,7 +103,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willReturn($mockCoins);
 
-        $response = $this->get('/api/v1/coins/search?q=bitcoin');
+        $response = $this->get('/v1/coins/search?q=bitcoin');
 
         $response->assertStatus(200);
         $response->assertJson([
@@ -120,7 +120,7 @@ class CoinControllerTest extends TestCase
      */
     public function test_search_endpoint_without_query_parameter_returns_422(): void
     {
-        $response = $this->get('/api/v1/coins/search');
+        $response = $this->get('/v1/coins/search');
 
         $response->assertStatus(422);
         $response->assertJson([
@@ -134,7 +134,7 @@ class CoinControllerTest extends TestCase
      */
     public function test_search_endpoint_with_empty_query_returns_422(): void
     {
-        $response = $this->get('/api/v1/coins/search?q=');
+        $response = $this->get('/v1/coins/search?q=');
 
         $response->assertStatus(422);
         $response->assertJson([
@@ -166,7 +166,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willReturn($mockCoins);
 
-        $response = $this->get('/api/v1/coins/search?q=BITCOIN');
+        $response = $this->get('/v1/coins/search?q=BITCOIN');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1, 'data');
@@ -217,7 +217,7 @@ class CoinControllerTest extends TestCase
             }))
             ->willReturn($mockCoinDetails);
 
-        $response = $this->get('/api/v1/coins/btc');
+        $response = $this->get('/v1/coins/btc');
 
         $response->assertStatus(200);
         $response->assertJson([
@@ -249,7 +249,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willReturn($mockCoins);
 
-        $response = $this->get('/api/v1/coins/xyz');
+        $response = $this->get('/v1/coins/xyz');
 
         $response->assertStatus(404);
         $response->assertJson([
@@ -290,7 +290,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoinById')
             ->willReturn($mockCoinDetails);
 
-        $response = $this->get('/api/v1/coins/BTC');
+        $response = $this->get('/v1/coins/BTC');
 
         $response->assertStatus(200);
         $response->assertJsonPath('data.symbol', 'btc');
@@ -306,7 +306,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willThrowException(new \Exception('API error'));
 
-        $response = $this->get('/api/v1/coins/markets');
+        $response = $this->get('/v1/coins/markets');
 
         $response->assertStatus(500);
         $response->assertJson([
@@ -325,7 +325,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willThrowException(new \Exception('API error'));
 
-        $response = $this->get('/api/v1/coins/search?q=bitcoin');
+        $response = $this->get('/v1/coins/search?q=bitcoin');
 
         $response->assertStatus(500);
         $response->assertJson([
@@ -357,7 +357,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoinById')
             ->willThrowException(new \Exception('API error'));
 
-        $response = $this->get('/api/v1/coins/btc');
+        $response = $this->get('/v1/coins/btc');
 
         $response->assertStatus(500);
         $response->assertJson([
@@ -394,7 +394,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willReturn($mockCoins);
 
-        $response = $this->get('/api/v1/coins/search?q=eth');
+        $response = $this->get('/v1/coins/search?q=eth');
 
         $response->assertStatus(200);
         $response->assertJsonCount(3, 'data'); // All match "eth" in name or symbol
@@ -405,7 +405,7 @@ class CoinControllerTest extends TestCase
      */
     public function test_api_responses_include_security_headers(): void
     {
-        $response = $this->get('/api/v1/health');
+        $response = $this->get('/v1/health');
 
         $response->assertStatus(200);
         $response->assertHeader('X-Content-Type-Options', 'nosniff');
@@ -421,7 +421,7 @@ class CoinControllerTest extends TestCase
     {
         $longQuery = str_repeat('a', 101); // 101 characters exceeds max of 100
 
-        $response = $this->get("/api/v1/coins/search?q={$longQuery}");
+        $response = $this->get("/v1/coins/search?q={$longQuery}");
 
         $response->assertStatus(422);
         $response->assertJson([
@@ -434,7 +434,7 @@ class CoinControllerTest extends TestCase
      */
     public function test_search_endpoint_rejects_invalid_characters(): void
     {
-        $response = $this->get('/api/v1/coins/search?q=<script>alert(1)</script>');
+        $response = $this->get('/v1/coins/search?q=<script>alert(1)</script>');
 
         $response->assertStatus(422);
         $response->assertJson([
@@ -452,7 +452,7 @@ class CoinControllerTest extends TestCase
             ->method('getCoins')
             ->willReturn([]);
 
-        $response = $this->get('/api/v1/coins/markets');
+        $response = $this->get('/v1/coins/markets');
 
         $response->assertStatus(200);
         $response->assertHeader('X-RateLimit-Limit');

--- a/front-end/.env.example
+++ b/front-end/.env.example
@@ -1,3 +1,3 @@
 # Backend API Configuration
 # Set this to your Laravel backend API URL
-NUXT_PUBLIC_API_BASE_URL=http://localhost:8000/api
+NUXT_PUBLIC_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- Remove `/api` prefix from Laravel routes making endpoints root-level (e.g., `/api/v1/coins/markets` → `/v1/coins/markets`)
- Update CORS and security middleware to handle new route patterns
- Update frontend configuration and all documentation to reflect new endpoint structure

## Changes
- `bootstrap/app.php`: Set `apiPrefix: ''` to remove /api prefix
- `config/cors.php`: Update paths from `'api/*'` to `'v1/*'`
- `SecurityHeaders.php`: Update path check from `api/*` to `v1/*`
- `front-end/.env.example`: Remove `/api` from base URL
- `tests/Feature/CoinControllerTest.php`: Update all test paths
- `API.md`, `README.md`, `CLAUDE.md`: Update documentation with new paths

## Test plan
- [x] All 16 backend tests pass
- [x] Laravel Pint linter passes
- [x] Verify frontend works with new API base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)