### PR TITLE
#24 Make the front-page grid show 5 items per row

### DIFF
--- a/front-end/pages/index.vue
+++ b/front-end/pages/index.vue
@@ -20,7 +20,7 @@
         </div>
 
         <!-- Coins Grid -->
-        <div v-else-if="coins.length" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div v-else-if="coins.length" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
           <NuxtLink v-for="coin in coins" :key="coin.id" :to="`/coins/${coin.symbol}`">
             <Card class="flex h-full flex-col overflow-hidden transition-all hover:shadow-lg hover:ring-2 hover:ring-primary cursor-pointer bg-card text-card-foreground">
               <CardHeader class="pb-3">


### PR DESCRIPTION
## Summary
- Changed grid layout from 4 to 5 columns per row on xl breakpoint
- Better displays all 10 coins returned by the markets API

## Changes
- Updated `pages/index.vue` grid from `xl:grid-cols-4` to `xl:grid-cols-5`

## Test plan
- [x] All tests pass (15/15)
- [x] Visual inspection on different screen sizes
- [x] Verified 5 coins per row on xl breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)