### PR TITLE
#33 Remove Laravel frontend from dev command

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -45,7 +45,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" --names=server,queue,logs --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi",


### PR DESCRIPTION
## Summary
- Removed Laravel Vite frontend (`npm run dev`) from `composer run dev` command
- Prevents conflicts with separate Nuxt frontend development environment

## Changes
- Updated `backend/composer.json` dev script
- Removed `npm run dev` and its color/name from concurrently command
- Now runs only 3 processes: PHP server, queue listener, pail logs
- Removed 4th color (#fdba74) and "vite" name

## Test plan
- [x] `composer run dev` runs without Laravel Vite
- [x] Backend API still starts on port 8000
- [x] Queue listener and pail logs still work
- [x] Nuxt frontend can be run separately without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)