### PR TITLE
Add favicon meta links to Angular frontend

### DIFF
--- a/front-end-ng/src/index.html
+++ b/front-end-ng/src/index.html
@@ -5,7 +5,11 @@
   <title>CryptoBro - Cryptocurrency Tracker</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
+  <link rel="shortcut icon" href="favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+  <link rel="manifest" href="favicon/site.webmanifest">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary

- Added comprehensive favicon meta links to the Angular frontend's `index.html`
- Favicon files were already present in the `public/favicon/` directory but not properly linked
- Now matches the Nuxt frontend's favicon implementation with support for multiple icon formats and sizes

## Changes

Updated `front-end-ng/src/index.html` to include:
- PNG icon (96x96) for modern browsers
- SVG icon for scalable icons
- ICO fallback icon
- Apple touch icon (180x180) for iOS devices
- Web app manifest for PWA support

## Test plan

- ✓ Build Angular frontend successfully
- ✓ Verified all favicon links are present in the compiled HTML
- ✓ All favicon files exist in the public directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)